### PR TITLE
change calculating linkNumber in customStyle

### DIFF
--- a/src/vue3-mermaid.js
+++ b/src/vue3-mermaid.js
@@ -65,13 +65,15 @@ export default {
       const nodeStyles = nodes
         .filter((node) => node.style)
         .map((node) => `style ${node.id} ${node.style}`)
+      let index = 0
       const nodeLinkStyles = nodes
         .filter((node) => node.linkStyle)
         .map(
-          (node) =>
-            `linkStyle ${node.linkNumber || nodes.indexOf(node)} ${node.linkStyle
-            }`
-        )
+          (node) => {
+            let linkNumber = (node.linkNumber || node.linkNumber == '0' ? node.linkNumber : index)
+            index++
+            return `linkStyle ${linkNumber} ${node.linkStyle}`
+          })
       return nodeStyles.concat(styles).concat(nodeLinkStyles)
     },
     parseCode() {


### PR DESCRIPTION
when the value of linkNumber is null or 0, the index of node will be used. 
It is wrong 
- The first link begin from the node that is not first node
- The number of link is less than the number of node.